### PR TITLE
Register Application in Manifest for Android Getting Started

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -64,3 +64,13 @@ public class App extends Application {
   }
 }
 ```
+
+ For either option, the custom `Application` class must be registered in `AndroidManifest.xml`:
+ ```
+ <application
+   android:name=".App"
+   ...>
+   ...
+ </application>
+ ```
+ 


### PR DESCRIPTION
Include documentation that the developer needs to register the custom `Application` class in `AndroidManifest.xml` to correctly initialize Parse.

Pull request #446 achieves something similar but this has different language.